### PR TITLE
Fix the bug triggered by example 5bis

### DIFF
--- a/src/Incompatibility.elm
+++ b/src/Incompatibility.elm
@@ -246,7 +246,15 @@ fuse name t1 t2 incompatibility =
     -- Does this corresponds to `not none` as result of terms union?
     -- That is satisfied if no version is picked or if a version
     -- is picked that is anything.
-    insert name (Term.union t1 t2) incompatibility
+    let
+        termUnion =
+            Term.union t1 t2
+    in
+    if termUnion == Term.Negative Range.none then
+        incompatibility
+
+    else
+        insert name termUnion incompatibility
 
 
 {-| Insert a new package term inside an incompatibility.


### PR DESCRIPTION
Example 5bis reaches a state when the current step incompatibility is `{ root: 1.0.0, baz: not none }`. The `not none` term however is a term that is almost satisfied. Indeed it is satisfied if any version is picked and it is satisfied if no version is picked (since it's a negative term). So this incompatibility should be in the canonical form `{ root: 1.0.0 }` meaning root is not selectable and the algorithm has to stop.

This issue happens due to the fusion of incompatibilities for prior cause computation. The solution therefore consists in just checking that the union of two terms is different than `not none` or we simply do not add that term to the incompatibility.

The PR code also contains some debug logging that was helpful in spotting the issue.